### PR TITLE
用語の日本語化・平易化

### DIFF
--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -162,7 +162,7 @@ export function HRVChart({ data }: ChartsProps) {
         <CartesianGrid stroke={GRID_COLOR} strokeDasharray="3 3" vertical={false} />
         <XAxis dataKey="date" tickFormatter={shortDate} tick={{ fill: TEXT_COLOR, fontSize: 11 }} axisLine={false} tickLine={false} />
         <YAxis tick={{ fill: TEXT_COLOR, fontSize: 11 }} axisLine={false} tickLine={false} unit=" ms" width={52} domain={[0, yMax]} />
-        <Tooltip content={<CustomTooltip formatter={(p) => `RMSSD: ${Number(p.value).toFixed(1)} ms`} />} />
+        <Tooltip content={<CustomTooltip formatter={(p) => `HRV: ${Number(p.value).toFixed(1)} ms`} />} />
         <ReferenceArea y1={50} y2={yMax} fill="rgba(0,214,143,0.06)" ifOverflow="hidden" />
         <ReferenceArea y1={20} y2={50} fill="rgba(255,179,71,0.06)" ifOverflow="hidden" />
         <ReferenceArea y1={0} y2={20} fill="rgba(255,107,107,0.06)" ifOverflow="hidden" />
@@ -170,42 +170,6 @@ export function HRVChart({ data }: ChartsProps) {
           <LabelList dataKey="hrv" position="top" fill="#00d68f" fontSize={11} formatter={(v) => Number(v).toFixed(1)} />
         </Area>
       </AreaChart>
-    </ResponsiveContainer>
-  );
-}
-
-/* ── 回復スコア ── */
-
-export function RecoveryChart({ data }: ChartsProps) {
-  const chartData: Array<{ date: string; score: number; fill: string }> = [];
-  data.dates.forEach((d, i) => {
-    const s = data.recovery_scores[i];
-    if (s !== null) {
-      chartData.push({
-        date: d,
-        score: s,
-        fill: s >= 67 ? '#00d68f' : s >= 34 ? '#ffb347' : '#ff6b6b',
-      });
-    }
-  });
-
-  return (
-    <ResponsiveContainer width="100%" height={220}>
-      <BarChart data={chartData} margin={{ top: 24, right: 40, bottom: 4, left: 0 }}>
-        <CartesianGrid stroke={GRID_COLOR} strokeDasharray="3 3" vertical={false} />
-        <XAxis dataKey="date" tickFormatter={shortDate} tick={{ fill: TEXT_COLOR, fontSize: 11 }} axisLine={false} tickLine={false} />
-        <YAxis tick={{ fill: TEXT_COLOR, fontSize: 11 }} axisLine={false} tickLine={false} unit=" " width={36} domain={[0, 105]} />
-        <Tooltip content={<CustomTooltip formatter={(p) => `回復スコア: ${Number(p.value).toFixed(1)}/100`} />} />
-        <ReferenceArea y1={67} y2={100} fill="rgba(0,214,143,0.05)" ifOverflow="hidden" />
-        <ReferenceArea y1={34} y2={67} fill="rgba(255,179,71,0.05)" ifOverflow="hidden" />
-        <ReferenceArea y1={0} y2={34} fill="rgba(255,107,107,0.05)" ifOverflow="hidden" />
-        <Bar dataKey="score" radius={[3, 3, 0, 0]}>
-          {chartData.map((entry, i) => (
-            <Cell key={i} fill={entry.fill} />
-          ))}
-          <LabelList dataKey="score" position="top" fill={LABEL_COLOR} fontSize={13} formatter={(v) => Math.round(Number(v))} />
-        </Bar>
-      </BarChart>
     </ResponsiveContainer>
   );
 }

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -244,42 +244,52 @@ export function HRZoneDonut({ data }: ChartsProps) {
   }));
 
   return (
-    <ResponsiveContainer width="100%" height={220}>
-      <PieChart>
-        <Pie
-          data={pieData}
-          cx="50%"
-          cy="50%"
-          innerRadius={55}
-          outerRadius={80}
-          dataKey="value"
-          paddingAngle={1}
-          label={({ name, value }) => value > 0 ? `${name} ${value}分` : ''}
-          labelLine={{ stroke: TEXT_COLOR }}
-        >
-          {pieData.map((entry, i) => (
-            <Cell key={i} fill={entry.color} />
-          ))}
-        </Pie>
-        <Tooltip
-          content={({ active, payload }) => {
-            if (!active || !payload?.length) return null;
-            const d = payload[0].payload as { name: string; value: number; calories: number };
-            return (
-              <div className="rounded-md border border-border bg-card2 px-2.5 py-1.5 text-xs text-text">
-                <div>{d.name}</div>
-                <div>{d.value}分 / {d.calories} kcal</div>
-              </div>
-            );
-          }}
-        />
-        {rhr && (
-          <text x="50%" y="50%" textAnchor="middle" dominantBaseline="central" fill="#ff6b6b" style={{ fontSize: 22, fontWeight: 700 }}>
-            {rhr}
-            <tspan dx={2} style={{ fontSize: 12, fontWeight: 400 }}>bpm</tspan>
-          </text>
-        )}
-      </PieChart>
-    </ResponsiveContainer>
+    <div className="flex items-center gap-6">
+      <ResponsiveContainer width="50%" height={220}>
+        <PieChart>
+          <Pie
+            data={pieData}
+            cx="50%"
+            cy="50%"
+            innerRadius={55}
+            outerRadius={80}
+            dataKey="value"
+            paddingAngle={1}
+          >
+            {pieData.map((entry, i) => (
+              <Cell key={i} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload?.length) return null;
+              const d = payload[0].payload as { name: string; value: number; calories: number };
+              return (
+                <div className="rounded-md border border-border bg-card2 px-2.5 py-1.5 text-xs text-text">
+                  <div>{d.name}</div>
+                  <div>{d.value}分 / {d.calories} kcal</div>
+                </div>
+              );
+            }}
+          />
+          {rhr && (
+            <text x="50%" y="50%" textAnchor="middle" dominantBaseline="central" fill="#ff6b6b" style={{ fontSize: 22, fontWeight: 700 }}>
+              {rhr}
+              <tspan dx={2} style={{ fontSize: 12, fontWeight: 400 }}>bpm</tspan>
+            </text>
+          )}
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="flex flex-col gap-2 text-xs">
+        {pieData.map((d) => (
+          <div key={d.name} className="flex items-center gap-2">
+            <span className="h-3 w-3 rounded-sm" style={{ background: d.color }} />
+            <span className="text-text2">{d.name}</span>
+            <span className="font-bold text-text">{d.value}分</span>
+            <span className="text-text3">{d.calories} kcal</span>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,7 +9,6 @@ import {
   StepsChart,
   SleepStagesChart,
   HRVChart,
-  RecoveryChart,
   SpO2Chart,
   HRZoneDonut,
 } from './Charts';
@@ -78,16 +77,12 @@ export function Dashboard({ data }: DashboardProps) {
       </div>
 
       <div className="px-8 pb-5 max-md:px-4">
-        <SectionTitle>回復・自律神経</SectionTitle>
+        <SectionTitle>自律神経</SectionTitle>
         <ChartGrid>
           <Card>
             <CardHeader><CardTitle>HRV（自律神経ゆらぎ）</CardTitle></CardHeader>
             <CardContent><HRVChart data={data} /></CardContent>
             <CardFooter>※数値は個人差が大きいため、自分自身の推移を参考にしてください</CardFooter>
-          </Card>
-          <Card>
-            <CardHeader><CardTitle>回復スコア</CardTitle></CardHeader>
-            <CardContent><RecoveryChart data={data} /></CardContent>
           </Card>
         </ChartGrid>
       </div>

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -9,25 +9,10 @@ export function SummaryCards({ data }: SummaryCardsProps) {
   const last = data.dates.length - 1;
   if (last < 0) return null;
 
-  const score = data.recovery_scores[last];
   const sleepMin = data.sleep_minutes[last];
-
-  const scoreClass =
-    score !== null
-      ? score >= 67
-        ? 'text-success'
-        : score >= 34
-          ? 'text-warning'
-          : 'text-danger'
-      : '';
+  const sedentary = data.sedentary_minutes[last];
 
   const cards = [
-    {
-      label: '回復スコア',
-      val: score !== null ? String(Math.round(score)) : '—',
-      cls: scoreClass,
-      sub: score !== null ? (score >= 67 ? '良好' : score >= 34 ? '普通' : '低い') : 'データ不足',
-    },
     {
       label: '安静時心拍数',
       val: data.resting_hr[last] !== null ? String(data.resting_hr[last]) : '—',
@@ -64,6 +49,12 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       color: '#00bcd4',
       sub: '正常: 95〜100%',
     },
+    {
+      label: '座位時間',
+      val: sedentary !== null ? `${Math.floor(sedentary / 60)}h ${sedentary % 60}m` : '—',
+      color: '#7d8590',
+      sub: '長時間の座位に注意',
+    },
   ];
 
   return (
@@ -71,7 +62,7 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       {cards.map((c) => (
         <Card key={c.label} className="text-center">
           <div className="mb-1.5 text-[11px] tracking-wide text-text2">{c.label}</div>
-          <div className={`text-[32px] font-bold ${c.cls ?? ''}`} style={{ color: c.color ?? undefined }}>
+          <div className="text-[32px] font-bold" style={{ color: c.color ?? undefined }}>
             {c.val}
             {c.unit && <span className="text-[13px] text-text2">{c.unit}</span>}
           </div>

--- a/src/data/sampleData.ts
+++ b/src/data/sampleData.ts
@@ -16,7 +16,7 @@ export const sampleData: HealthData = {
   spo2_avg: [97.2, 96.8, 97.5, 96.5, 97.0, 97.3, 96.9],
   spo2_min: [95.0, 94.5, 95.2, 94.0, 95.1, 95.3, 94.8],
   spo2_max: [99.0, 98.5, 99.2, 98.0, 98.8, 99.1, 98.6],
-  recovery_scores: [65, 72, 58, 78, 68, 75, 70],
+  sedentary_minutes: [780, 720, 800, 690, 750, 760, 710],
   sleep_timelines: [
     null, null, null, null, null, null,
     {

--- a/src/types/health.ts
+++ b/src/types/health.ts
@@ -37,7 +37,7 @@ export interface HealthData {
   spo2_avg: (number | null)[];
   spo2_min: (number | null)[];
   spo2_max: (number | null)[];
-  recovery_scores: (number | null)[];
+  sedentary_minutes: (number | null)[];
   sleep_timelines: (SleepTimeline | null)[];
   hr_zones: (HRZone[] | null)[];
   goals: (Goals | null)[];


### PR DESCRIPTION
## Summary
- 回復スコア（Recovery Score）をUI・型定義・サンプルデータからすべて削除（APIで取得できていないため）
- 座位時間（sedentaryMinutes）をサマリーカードに新規追加
- HRVチャートのツールチップ表記を `RMSSD` から `HRV` に変更
- ダッシュボードのセクション名を「回復・自律神経」→「自律神経」に変更

## Test plan
- [ ] ダッシュボードが正常に表示されること
- [ ] サマリーカードに「座位時間」が表示されること
- [ ] 回復スコアのカード・チャートが表示されないこと
- [ ] HRVチャートのツールチップが「HRV: XX ms」と表示されること
- [ ] ビルドがエラーなく通ること

Closes #24

https://claude.ai/code/session_01PqPJEbHRZxtfLsE9yt2LDS