### PR TITLE
feat: UX改善まとめ — 日付ナビ・ドリルダウン・スパークライン・アニメーション (#47〜#51)

### DIFF
--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -105,8 +105,8 @@ export function StepsChart({ data }: ChartsProps) {
 /* ── 睡眠ステージ ── */
 
 const SLEEP_STAGES = [
-  { key: 'deep', name: '深い眠り', color: '#1a237e' },
-  { key: 'light', name: '浅い眠り', color: '#5c6bc0' },
+  { key: 'deep', name: '深い眠り', color: '#3949ab' },
+  { key: 'light', name: '浅い眠り', color: '#9fa8da' },
   { key: 'rem', name: 'レム睡眠', color: '#26a69a' },
   { key: 'wake', name: '覚醒', color: '#ef5350' },
 ] as const;
@@ -140,7 +140,8 @@ export function SleepStagesChart({ data }: ChartsProps) {
         />
         <Legend
           verticalAlign="top"
-          wrapperStyle={{ fontSize: 10, color: TEXT_COLOR, paddingBottom: 8 }}
+          formatter={(value) => <span style={{ color: TEXT_COLOR }}>{value}</span>}
+          wrapperStyle={{ fontSize: 10, paddingBottom: 8 }}
         />
         {SLEEP_STAGES.map((s) => (
           <Bar key={s.key} dataKey={s.key} name={s.name} stackId="sleep" fill={s.color} />
@@ -227,7 +228,7 @@ const ZONE_NAME_MAP: Record<string, string> = {
   'Fat Burn': '脂肪燃焼帯', Cardio: '有酸素帯', Peak: '最大強度帯', 'Out of Range': '安静帯',
 };
 const ZONE_COLORS: Record<string, string> = {
-  'Fat Burn': '#ffb347', Cardio: '#ff6b6b', Peak: '#e040fb', 'Out of Range': '#2a2d3a',
+  'Fat Burn': '#ffb347', Cardio: '#ff6b6b', Peak: '#e040fb', 'Out of Range': '#3d4451',
 };
 
 export function HRZoneDonut({ data }: ChartsProps) {
@@ -242,14 +243,20 @@ export function HRZoneDonut({ data }: ChartsProps) {
     value: z.minutes,
     calories: Math.round(z.caloriesOut),
     color: ZONE_COLORS[z.name] || '#555',
+    active: z.name !== 'Out of Range',
   }));
 
+  // 安静帯は滞在時間が支配的でドーナツが潰れるため、活動ゾーンのみ描画する
+  const activeZones = pieData.filter(d => d.active);
+  const donutData = activeZones.length > 0 ? activeZones : pieData;
+
   return (
-    <div className="flex items-center gap-6">
-      <ResponsiveContainer width="50%" height={220}>
+    <div className="flex items-center gap-6 max-sm:flex-col max-sm:gap-2">
+      <div className="h-[220px] w-1/2 max-sm:w-full">
+      <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Pie
-            data={pieData}
+            data={donutData}
             cx="50%"
             cy="50%"
             innerRadius={55}
@@ -257,7 +264,7 @@ export function HRZoneDonut({ data }: ChartsProps) {
             dataKey="value"
             paddingAngle={1}
           >
-            {pieData.map((entry, i) => (
+            {donutData.map((entry, i) => (
               <Cell key={i} fill={entry.color} />
             ))}
           </Pie>
@@ -281,15 +288,19 @@ export function HRZoneDonut({ data }: ChartsProps) {
           )}
         </PieChart>
       </ResponsiveContainer>
+      </div>
       <div className="flex flex-col gap-2 text-xs">
         {pieData.map((d) => (
           <div key={d.name} className="flex items-center gap-2">
-            <span className="h-3 w-3 rounded-sm" style={{ background: d.color }} />
+            <span className="h-3 w-3 shrink-0 rounded-sm" style={{ background: d.color }} />
             <span className="text-text2">{d.name}</span>
             <span className="font-bold text-text">{d.value}分</span>
             <span className="text-text3">{d.calories} kcal</span>
           </div>
         ))}
+        {activeZones.length > 0 && (
+          <div className="mt-1 text-[10px] text-text3">※グラフは活動ゾーンのみ表示</div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -231,12 +231,17 @@ const ZONE_COLORS: Record<string, string> = {
   'Fat Burn': '#ffb347', Cardio: '#ff6b6b', Peak: '#e040fb', 'Out of Range': '#3d4451',
 };
 
-export function HRZoneDonut({ data }: ChartsProps) {
-  const last = data.dates.length - 1;
-  const zones = data.hr_zones[last] || [];
-  const rhr = data.resting_hr[last];
+export function HRZoneDonut({ data, index }: ChartsProps & { index: number }) {
+  const zones = data.hr_zones[index] || [];
+  const rhr = data.resting_hr[index];
 
-  if (zones.length === 0 && !rhr) return null;
+  if (zones.length === 0) {
+    return (
+      <div className="flex h-[220px] items-center justify-center text-xs text-text2">
+        この日の心拍ゾーンデータはありません
+      </div>
+    );
+  }
 
   const pieData = zones.map(z => ({
     name: ZONE_NAME_MAP[z.name] || z.name,

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -384,7 +384,8 @@ export function BodyCompositionChart({ data }: ChartsProps) {
         />
         <Legend
           verticalAlign="top"
-          wrapperStyle={{ fontSize: 10, color: TEXT_COLOR, paddingBottom: 8 }}
+          formatter={(value) => <span style={{ color: TEXT_COLOR }}>{value}</span>}
+          wrapperStyle={{ fontSize: 10, paddingBottom: 8 }}
         />
         <Line
           yAxisId="weight"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,10 +1,13 @@
+import { useMemo, useRef, useState } from 'react';
 import type { HealthData } from '../types/health';
 import { Header } from './Header';
+import { DateStrip } from './DateStrip';
 import { HeroScore } from './HeroScore';
 import { SummaryCards } from './SummaryCards';
 import { GoalRings } from './GoalRings';
 import { SleepTimeline } from './SleepTimeline';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from './ui/Card';
+import { readinessScore, zoneFor } from '../lib/readiness';
 import {
   RestingHRChart,
   StepsChart,
@@ -35,85 +38,130 @@ function ChartGrid({ children }: { children: React.ReactNode }) {
   );
 }
 
+const SWIPE_THRESHOLD = 60;
+
 export function Dashboard({ data }: DashboardProps) {
   const last = data.dates.length - 1;
+  const [selectedIdx, setSelectedIdx] = useState(last);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+
+  const dotColors = useMemo(
+    () =>
+      data.dates.map((_, i) => {
+        const s = readinessScore(data, i);
+        return s === null ? null : zoneFor(s).color;
+      }),
+    [data],
+  );
+
+  const select = (i: number) => {
+    setSelectedIdx(Math.max(0, Math.min(last, i)));
+  };
+
+  // 左スワイプ=翌日 / 右スワイプ=前日（縦スクロールと区別するため横成分優位のみ）
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    const start = touchStart.current;
+    touchStart.current = null;
+    if (!start) return;
+    const dx = e.changedTouches[0].clientX - start.x;
+    const dy = e.changedTouches[0].clientY - start.y;
+    if (Math.abs(dx) < SWIPE_THRESHOLD || Math.abs(dx) < Math.abs(dy) * 1.5) return;
+    select(selectedIdx + (dx < 0 ? 1 : -1));
+  };
 
   return (
     <>
       <Header lastDate={last >= 0 ? data.dates[last] : ''} />
-      <HeroScore data={data} />
-      <SummaryCards data={data} />
+      <DateStrip
+        dates={data.dates}
+        selected={selectedIdx}
+        onSelect={select}
+        dotColors={dotColors}
+      />
 
-      <div className="px-8 max-md:px-4">
-        <SectionTitle>活動目標の達成率</SectionTitle>
-      </div>
-      <GoalRings data={data} />
+      <div
+        key={selectedIdx >= 0 ? data.dates[selectedIdx] : 'empty'}
+        className="animate-fade-slide"
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+      >
+        <HeroScore data={data} index={selectedIdx} />
+        <SummaryCards data={data} index={selectedIdx} />
 
-      <div className="px-8 pb-5 max-md:px-4">
-        <SectionTitle>睡眠</SectionTitle>
-        <ChartGrid>
-          <Card className="flex flex-col">
-            <CardHeader><CardTitle>睡眠タイムライン</CardTitle></CardHeader>
-            <CardContent className="flex flex-1 flex-col justify-center">
-              <SleepTimeline timeline={last >= 0 ? data.sleep_timelines[last] : null} />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader><CardTitle>睡眠ステージ推移</CardTitle></CardHeader>
-            <CardContent><SleepStagesChart data={data} /></CardContent>
-          </Card>
-        </ChartGrid>
-      </div>
+        <div className="px-8 max-md:px-4">
+          <SectionTitle>活動目標の達成率</SectionTitle>
+        </div>
+        <GoalRings data={data} index={selectedIdx} />
 
-      <div className="px-8 pb-5 max-md:px-4">
-        <SectionTitle>心臓・循環器</SectionTitle>
-        <ChartGrid>
-          <Card>
-            <CardHeader><CardTitle>安静時心拍数</CardTitle></CardHeader>
-            <CardContent><RestingHRChart data={data} /></CardContent>
-          </Card>
-          <Card>
-            <CardHeader><CardTitle>心拍ゾーン（本日）</CardTitle></CardHeader>
-            <CardContent><HRZoneDonut data={data} /></CardContent>
-          </Card>
-        </ChartGrid>
-      </div>
+        <div className="px-8 pb-5 max-md:px-4">
+          <SectionTitle>睡眠</SectionTitle>
+          <ChartGrid>
+            <Card className="flex flex-col">
+              <CardHeader><CardTitle>睡眠タイムライン</CardTitle></CardHeader>
+              <CardContent className="flex flex-1 flex-col justify-center">
+                <SleepTimeline timeline={selectedIdx >= 0 ? data.sleep_timelines[selectedIdx] : null} />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle>睡眠ステージ推移</CardTitle></CardHeader>
+              <CardContent><SleepStagesChart data={data} /></CardContent>
+            </Card>
+          </ChartGrid>
+        </div>
 
-      <div className="px-8 pb-5 max-md:px-4">
-        <SectionTitle>自律神経</SectionTitle>
-        <ChartGrid>
-          <Card>
-            <CardHeader><CardTitle>HRV（自律神経ゆらぎ）</CardTitle></CardHeader>
-            <CardContent><HRVChart data={data} /></CardContent>
-            <CardFooter>※数値は個人差が大きいため、自分自身の推移を参考にしてください</CardFooter>
-          </Card>
-        </ChartGrid>
-      </div>
+        <div className="px-8 pb-5 max-md:px-4">
+          <SectionTitle>心臓・循環器</SectionTitle>
+          <ChartGrid>
+            <Card>
+              <CardHeader><CardTitle>安静時心拍数</CardTitle></CardHeader>
+              <CardContent><RestingHRChart data={data} /></CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle>心拍ゾーン</CardTitle></CardHeader>
+              <CardContent><HRZoneDonut data={data} index={selectedIdx} /></CardContent>
+            </Card>
+          </ChartGrid>
+        </div>
 
-      <div className="px-8 pb-5 max-md:px-4">
-        <SectionTitle>血中酸素・歩数</SectionTitle>
-        <ChartGrid>
-          <Card>
-            <CardHeader><CardTitle>血中酸素濃度 (SpO2)</CardTitle></CardHeader>
-            <CardContent><SpO2Chart data={data} /></CardContent>
-            <CardFooter>※正常範囲: 95〜100% 睡眠中に計測</CardFooter>
-          </Card>
-          <Card>
-            <CardHeader><CardTitle>歩数</CardTitle></CardHeader>
-            <CardContent><StepsChart data={data} /></CardContent>
-          </Card>
-        </ChartGrid>
-      </div>
+        <div className="px-8 pb-5 max-md:px-4">
+          <SectionTitle>自律神経</SectionTitle>
+          <ChartGrid>
+            <Card>
+              <CardHeader><CardTitle>HRV（自律神経ゆらぎ）</CardTitle></CardHeader>
+              <CardContent><HRVChart data={data} /></CardContent>
+              <CardFooter>※数値は個人差が大きいため、自分自身の推移を参考にしてください</CardFooter>
+            </Card>
+          </ChartGrid>
+        </div>
 
-      <div className="px-8 pb-5 max-md:px-4">
-        <SectionTitle>体組成</SectionTitle>
-        <ChartGrid>
-          <Card>
-            <CardHeader><CardTitle>体重・体脂肪率の推移</CardTitle></CardHeader>
-            <CardContent><BodyCompositionChart data={data} /></CardContent>
-            <CardFooter>※TANITA 体組成計のデータ</CardFooter>
-          </Card>
-        </ChartGrid>
+        <div className="px-8 pb-5 max-md:px-4">
+          <SectionTitle>血中酸素・歩数</SectionTitle>
+          <ChartGrid>
+            <Card>
+              <CardHeader><CardTitle>血中酸素濃度 (SpO2)</CardTitle></CardHeader>
+              <CardContent><SpO2Chart data={data} /></CardContent>
+              <CardFooter>※正常範囲: 95〜100% 睡眠中に計測</CardFooter>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle>歩数</CardTitle></CardHeader>
+              <CardContent><StepsChart data={data} /></CardContent>
+            </Card>
+          </ChartGrid>
+        </div>
+
+        <div className="px-8 pb-5 max-md:px-4">
+          <SectionTitle>体組成</SectionTitle>
+          <ChartGrid>
+            <Card>
+              <CardHeader><CardTitle>体重・体脂肪率の推移</CardTitle></CardHeader>
+              <CardContent><BodyCompositionChart data={data} /></CardContent>
+              <CardFooter>※TANITA 体組成計のデータ</CardFooter>
+            </Card>
+          </ChartGrid>
+        </div>
       </div>
     </>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -52,9 +52,9 @@ export function Dashboard({ data }: DashboardProps) {
       <div className="px-8 pb-5 max-md:px-4">
         <SectionTitle>睡眠</SectionTitle>
         <ChartGrid>
-          <Card>
+          <Card className="flex flex-col">
             <CardHeader><CardTitle>睡眠タイムライン</CardTitle></CardHeader>
-            <CardContent>
+            <CardContent className="flex flex-1 flex-col justify-center">
               <SleepTimeline timeline={last >= 0 ? data.sleep_timelines[last] : null} />
             </CardContent>
           </Card>

--- a/src/components/DateStrip.tsx
+++ b/src/components/DateStrip.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { BottomSheet } from './ui/BottomSheet';
+
+interface DateStripProps {
+  dates: string[];
+  selected: number;
+  onSelect: (index: number) => void;
+  /** 各日のスコア品質ドット色。データなしは null */
+  dotColors: (string | null)[];
+}
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
+
+function parseDate(d: string): Date {
+  return new Date(`${d}T00:00:00`);
+}
+
+interface CalendarGridProps {
+  dates: string[];
+  selected: number;
+  dotColors: (string | null)[];
+  onSelect: (index: number) => void;
+  onClose: () => void;
+}
+
+function CalendarGrid({ dates, selected, dotColors, onSelect, onClose }: CalendarGridProps) {
+  const indexByDate = useMemo(() => {
+    const m = new Map<string, number>();
+    dates.forEach((d, i) => m.set(d, i));
+    return m;
+  }, [dates]);
+
+  const first = parseDate(dates[0]);
+  const lastD = parseDate(dates[dates.length - 1]);
+  const sel = parseDate(dates[selected]);
+  const [viewYear, setViewYear] = useState(sel.getFullYear());
+  const [viewMonth, setViewMonth] = useState(sel.getMonth());
+
+  const canPrev = viewYear > first.getFullYear() ||
+    (viewYear === first.getFullYear() && viewMonth > first.getMonth());
+  const canNext = viewYear < lastD.getFullYear() ||
+    (viewYear === lastD.getFullYear() && viewMonth < lastD.getMonth());
+
+  const moveMonth = (delta: number) => {
+    const d = new Date(viewYear, viewMonth + delta, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  const firstDow = new Date(viewYear, viewMonth, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const cells: (number | null)[] = [
+    ...Array.from({ length: firstDow }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+
+  const pad = (n: number) => String(n).padStart(2, '0');
+
+  return (
+    <BottomSheet title="カレンダー" onClose={onClose} snapPoints={[55, 85]}>
+      <div className="mb-3 flex items-center justify-between">
+        <button
+          onClick={() => moveMonth(-1)}
+          disabled={!canPrev}
+          className="rounded px-2 py-1 text-sm text-text2 hover:text-text disabled:opacity-30"
+          aria-label="前の月"
+        >
+          ‹
+        </button>
+        <div className="text-sm font-semibold text-text">{viewYear}年{viewMonth + 1}月</div>
+        <button
+          onClick={() => moveMonth(1)}
+          disabled={!canNext}
+          className="rounded px-2 py-1 text-sm text-text2 hover:text-text disabled:opacity-30"
+          aria-label="次の月"
+        >
+          ›
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-1 text-center">
+        {WEEKDAYS.map((w) => (
+          <div key={w} className="py-1 text-[11px] text-text3">{w}</div>
+        ))}
+        {cells.map((day, i) => {
+          if (day === null) return <div key={`pad-${i}`} />;
+          const dateStr = `${viewYear}-${pad(viewMonth + 1)}-${pad(day)}`;
+          const idx = indexByDate.get(dateStr);
+          const isSelected = idx === selected;
+          if (idx === undefined) {
+            return (
+              <div key={dateStr} className="py-1.5 text-sm text-text3/60">{day}</div>
+            );
+          }
+          return (
+            <button
+              key={dateStr}
+              onClick={() => { onSelect(idx); onClose(); }}
+              className={`flex flex-col items-center rounded-lg py-1.5 text-sm transition-colors ${
+                isSelected ? 'bg-accent/20 font-bold text-accent' : 'text-text hover:bg-card2'
+              }`}
+            >
+              {day}
+              <span
+                className="mt-0.5 h-1.5 w-1.5 rounded-full"
+                style={{ background: dotColors[idx] ?? '#484f58' }}
+              />
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-3 text-[10px] text-text3">
+        <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-[#10b981]" />最適</span>
+        <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-[#f59e0b]" />良好</span>
+        <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-[#f43f5e]" />要注意</span>
+        <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-[#484f58]" />データなし</span>
+      </div>
+    </BottomSheet>
+  );
+}
+
+export function DateStrip({ dates, selected, onSelect, dotColors }: DateStripProps) {
+  const [calendarOpen, setCalendarOpen] = useState(false);
+  const selectedRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+  }, [selected]);
+
+  if (dates.length === 0) return null;
+
+  const sel = parseDate(dates[selected]);
+  const isToday = selected === dates.length - 1;
+
+  return (
+    <>
+      <div className="sticky top-0 z-40 flex items-center gap-3 border-b border-border bg-bg/95 px-8 py-2 backdrop-blur max-md:px-4">
+        <button
+          onClick={() => setCalendarOpen(true)}
+          className="shrink-0 rounded-lg px-2 py-1 text-[13px] font-semibold text-text hover:bg-card2"
+          aria-label="カレンダーを開く"
+        >
+          {sel.getFullYear()}年{sel.getMonth() + 1}月 <span className="text-text3">▾</span>
+        </button>
+        <div className="flex flex-1 gap-1 overflow-x-auto scroll-smooth py-1 [scrollbar-width:none]">
+          {dates.map((d, i) => {
+            const dt = parseDate(d);
+            const isSelected = i === selected;
+            return (
+              <button
+                key={d}
+                ref={isSelected ? selectedRef : undefined}
+                onClick={() => onSelect(i)}
+                className={`flex w-11 shrink-0 flex-col items-center rounded-lg border py-1 transition-colors ${
+                  isSelected
+                    ? 'border-accent bg-accent/15'
+                    : 'border-transparent hover:bg-card2'
+                }`}
+                aria-label={d}
+                aria-current={isSelected ? 'date' : undefined}
+              >
+                <span className="text-[10px] text-text3">{WEEKDAYS[dt.getDay()]}</span>
+                <span className={`text-sm font-semibold ${isSelected ? 'text-accent' : 'text-text'}`}>
+                  {dt.getDate()}
+                </span>
+                <span
+                  className="mt-0.5 h-1.5 w-1.5 rounded-full"
+                  style={{ background: dotColors[i] ?? '#484f58' }}
+                />
+              </button>
+            );
+          })}
+        </div>
+        <button
+          onClick={() => onSelect(dates.length - 1)}
+          disabled={isToday}
+          className="shrink-0 rounded-full border border-accent px-3 py-1 text-xs font-semibold text-accent transition-opacity hover:bg-accent/10 disabled:opacity-30"
+        >
+          今日
+        </button>
+      </div>
+      {calendarOpen && (
+        <CalendarGrid
+          dates={dates}
+          selected={selected}
+          dotColors={dotColors}
+          onSelect={onSelect}
+          onClose={() => setCalendarOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/GoalRings.tsx
+++ b/src/components/GoalRings.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react';
 import type { HealthData } from '../types/health';
 import { Card } from './ui/Card';
+import { CountUp } from './ui/CountUp';
+import { useReducedMotion } from '../lib/useReducedMotion';
 
 interface GoalRingsProps {
   data: HealthData;
@@ -7,6 +10,15 @@ interface GoalRingsProps {
 }
 
 export function GoalRings({ data, index }: GoalRingsProps) {
+  // マウント時に 0% からリングを充填する（reduced-motion 時は即時表示）
+  const reduced = useReducedMotion();
+  const [filled, setFilled] = useState(reduced);
+  useEffect(() => {
+    if (reduced) return;
+    const id = requestAnimationFrame(() => setFilled(true));
+    return () => cancelAnimationFrame(id);
+  }, [reduced]);
+
   if (index < 0 || index >= data.dates.length) return null;
 
   const goals = data.goals[index] || {};
@@ -27,18 +39,23 @@ export function GoalRings({ data, index }: GoalRingsProps) {
 
         return (
           <Card key={item.label} className="text-center">
-            <div className="relative mx-auto mb-2 h-[100px] w-[100px]">
+            <div
+              className={`relative mx-auto mb-2 h-[100px] w-[100px] ${
+                achieved && !reduced ? 'animate-goal-pop' : ''
+              }`}
+            >
               <svg className="h-full w-full -rotate-90" viewBox="0 0 100 100">
                 <circle cx="50" cy="50" r="40" fill="none" stroke="#21262d" strokeWidth="6" />
                 <circle
                   cx="50" cy="50" r="40" fill="none"
                   stroke={color} strokeWidth="6"
-                  strokeDasharray={`${dashLen} 251.2`}
+                  strokeDasharray={`${filled ? dashLen : 0} 251.2`}
                   strokeLinecap="round"
+                  style={{ transition: 'stroke-dasharray 0.8s ease-out' }}
                 />
               </svg>
               <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-bold" style={{ color }}>
-                {Math.round(pct)}%
+                <CountUp value={Math.round(pct)} format={(v) => `${Math.round(v)}%`} />
               </div>
             </div>
             <div className="text-[11px] text-text2">{item.label}</div>

--- a/src/components/GoalRings.tsx
+++ b/src/components/GoalRings.tsx
@@ -3,17 +3,17 @@ import { Card } from './ui/Card';
 
 interface GoalRingsProps {
   data: HealthData;
+  index: number;
 }
 
-export function GoalRings({ data }: GoalRingsProps) {
-  const last = data.dates.length - 1;
-  if (last < 0) return null;
+export function GoalRings({ data, index }: GoalRingsProps) {
+  if (index < 0 || index >= data.dates.length) return null;
 
-  const goals = data.goals[last] || {};
+  const goals = data.goals[index] || {};
   const items = [
-    { label: '歩数', actual: data.steps[last], goal: goals.steps ?? 10000, unit: '歩' },
+    { label: '歩数', actual: data.steps[index], goal: goals.steps ?? 10000, unit: '歩' },
     { label: '距離', actual: 0, goal: goals.distance ?? 8.05, unit: 'km', decimals: 1 },
-    { label: '消費カロリー', actual: data.active_calories[last] || 0, goal: goals.caloriesOut ?? 2244, unit: 'kcal' },
+    { label: '消費カロリー', actual: data.active_calories[index] || 0, goal: goals.caloriesOut ?? 2244, unit: 'kcal' },
     { label: '活動時間', actual: 0, goal: goals.activeMinutes ?? 30, unit: '分' },
   ];
 

--- a/src/components/HeroScore.tsx
+++ b/src/components/HeroScore.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import type { HealthData } from '../types/health';
 import { Card } from './ui/Card';
 import { BottomSheet } from './ui/BottomSheet';
+import { CountUp } from './ui/CountUp';
 import { computeContributors, hasDataAt, zoneFor, type Contributor } from '../lib/readiness';
+import { useReducedMotion } from '../lib/useReducedMotion';
 
 interface HeroScoreProps {
   data: HealthData;
@@ -38,6 +40,15 @@ function ScoreRing({ score, color }: ScoreRingProps) {
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (score / 100) * circumference;
 
+  // マウント時に 0 からアークを描画する（reduced-motion 時は即時表示）
+  const reduced = useReducedMotion();
+  const [drawn, setDrawn] = useState(reduced);
+  useEffect(() => {
+    if (reduced) return;
+    const id = requestAnimationFrame(() => setDrawn(true));
+    return () => cancelAnimationFrame(id);
+  }, [reduced]);
+
   return (
     <svg width={size} height={size} className="block" role="img" aria-label={`Readiness score ${score}`}>
       <circle
@@ -57,7 +68,7 @@ function ScoreRing({ score, color }: ScoreRingProps) {
         strokeWidth={stroke}
         strokeLinecap="round"
         strokeDasharray={circumference}
-        strokeDashoffset={offset}
+        strokeDashoffset={drawn ? offset : circumference}
         transform={`rotate(-90 ${size / 2} ${size / 2})`}
         style={{ transition: 'stroke-dashoffset 1.2s ease-out' }}
       />
@@ -70,7 +81,7 @@ function ScoreRing({ score, color }: ScoreRingProps) {
         fontSize="56"
         fontWeight="700"
       >
-        {score}
+        <CountUp value={score} format={(v) => String(Math.round(v))} duration={1000} />
       </text>
     </svg>
   );

--- a/src/components/HeroScore.tsx
+++ b/src/components/HeroScore.tsx
@@ -1,138 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { HealthData } from '../types/health';
 import { Card } from './ui/Card';
+import { BottomSheet } from './ui/BottomSheet';
+import { computeContributors, hasDataAt, zoneFor, type Contributor } from '../lib/readiness';
 
 interface HeroScoreProps {
   data: HealthData;
-}
-
-interface Contributor {
-  label: string;
-  score: number;
-  weight: number;
-  detail: string;
-  baseline: string;
-}
-
-function avg(values: (number | null)[]): number | null {
-  const nums = values.filter((v): v is number => v !== null && !Number.isNaN(v));
-  if (nums.length === 0) return null;
-  return nums.reduce((a, b) => a + b, 0) / nums.length;
-}
-
-function clamp(n: number, min = 0, max = 100): number {
-  return Math.max(min, Math.min(max, n));
-}
-
-function signed(n: number): string {
-  return n > 0 ? `+${n}` : `${n}`;
-}
-
-function computeContributors(data: HealthData): Contributor[] {
-  const last = data.dates.length - 1;
-  if (last < 0) return [];
-
-  // Sleep duration: 480 min (8h) target
-  const sleepMin = data.sleep_minutes[last] ?? 0;
-  const sleepDurTarget = 480;
-  const sleepDurScore = clamp((sleepMin / sleepDurTarget) * 100);
-  const sleepHours = Math.floor(sleepMin / 60);
-  const sleepRemMin = sleepMin % 60;
-  const sleepDiffMin = sleepMin - sleepDurTarget;
-
-  // Sleep efficiency: target 90%
-  const sleepEff = data.sleep_efficiency[last] ?? null;
-  const sleepEffTarget = 90;
-  const sleepEffScore = sleepEff !== null
-    ? clamp(50 + (sleepEff - sleepEffTarget) * 5)
-    : 50;
-
-  // Deep sleep: target 90 min
-  const deepMin = data.deep[last] ?? 0;
-  const deepTarget = 90;
-  const deepScore = clamp((deepMin / deepTarget) * 100);
-
-  // HRV: compare last vs personal baseline (mean of series)
-  const hrvBaseline = avg(data.hrv_rmssd);
-  const hrvLast = data.hrv_rmssd[last];
-  const hrvScore = hrvLast !== null && hrvBaseline !== null && hrvBaseline > 0
-    ? clamp(50 + ((hrvLast - hrvBaseline) / hrvBaseline) * 100)
-    : 50;
-  const hrvDiffPct = hrvLast !== null && hrvBaseline !== null && hrvBaseline > 0
-    ? Math.round(((hrvLast - hrvBaseline) / hrvBaseline) * 100)
-    : null;
-
-  // Resting HR: lower vs baseline is better
-  const rhrBaseline = avg(data.resting_hr);
-  const rhrLast = data.resting_hr[last];
-  const rhrScore = rhrLast !== null && rhrBaseline !== null && rhrBaseline > 0
-    ? clamp(50 - ((rhrLast - rhrBaseline) / rhrBaseline) * 100)
-    : 50;
-  const rhrDiff = rhrLast !== null && rhrBaseline !== null
-    ? rhrLast - Math.round(rhrBaseline)
-    : null;
-
-  // Activity: steps vs daily goal (default 10k)
-  const stepsGoal = data.goals[last]?.steps ?? 10000;
-  const steps = data.steps[last] ?? 0;
-  const activityScore = clamp((steps / stepsGoal) * 100);
-
-  return [
-    {
-      label: '睡眠時間',
-      score: Math.round(sleepDurScore),
-      weight: 0.25,
-      detail: `${sleepHours}時間${sleepRemMin}分`,
-      baseline: `目標 ${sleepDurTarget / 60}時間に対し ${signed(sleepDiffMin)}分`,
-    },
-    {
-      label: '睡眠効率',
-      score: Math.round(sleepEffScore),
-      weight: 0.1,
-      detail: sleepEff !== null ? `${sleepEff}%` : '—',
-      baseline: sleepEff !== null
-        ? `目標 ${sleepEffTarget}% に対し ${signed(sleepEff - sleepEffTarget)}pt`
-        : 'データなし',
-    },
-    {
-      label: '深い睡眠',
-      score: Math.round(deepScore),
-      weight: 0.1,
-      detail: `${deepMin}分`,
-      baseline: `目標 ${deepTarget}分に対し ${signed(deepMin - deepTarget)}分`,
-    },
-    {
-      label: 'HRV',
-      score: Math.round(hrvScore),
-      weight: 0.2,
-      detail: hrvLast !== null ? `${hrvLast.toFixed(1)} ms` : '—',
-      baseline: hrvBaseline !== null && hrvDiffPct !== null
-        ? `平均 ${hrvBaseline.toFixed(1)} ms に対し ${signed(hrvDiffPct)}%`
-        : 'データなし',
-    },
-    {
-      label: '安静時心拍',
-      score: Math.round(rhrScore),
-      weight: 0.15,
-      detail: rhrLast !== null ? `${rhrLast} bpm` : '—',
-      baseline: rhrBaseline !== null && rhrDiff !== null
-        ? `平均 ${Math.round(rhrBaseline)} bpm に対し ${signed(rhrDiff)} bpm`
-        : 'データなし',
-    },
-    {
-      label: 'アクティビティ',
-      score: Math.round(activityScore),
-      weight: 0.2,
-      detail: `${steps.toLocaleString()} 歩`,
-      baseline: `目標 ${stepsGoal.toLocaleString()} 歩に対し ${Math.round((steps / stepsGoal) * 100)}%`,
-    },
-  ];
-}
-
-function zoneFor(score: number): { color: string; ring: string; label: string } {
-  if (score >= 85) return { color: '#10b981', ring: '#10b981', label: '最適' };
-  if (score >= 70) return { color: '#f59e0b', ring: '#f59e0b', label: '良好' };
-  return { color: '#f43f5e', ring: '#f43f5e', label: '要注意' };
+  index: number;
 }
 
 /**
@@ -252,51 +126,28 @@ function ContributorList({ contributors }: ContributorListProps) {
   );
 }
 
-interface DetailSheetProps {
-  contributors: Contributor[];
-  onClose: () => void;
-}
-
-function DetailSheet({ contributors, onClose }: DetailSheetProps) {
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 sm:items-center"
-      onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-    >
-      <div
-        className="w-full max-w-md rounded-t-2xl border border-border bg-card p-5 sm:rounded-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <h3 className="text-base font-semibold text-text">Contributors</h3>
-          <button
-            onClick={onClose}
-            className="text-text2 hover:text-text"
-            aria-label="閉じる"
-          >
-            ✕
-          </button>
-        </div>
-        <ContributorList contributors={contributors} />
-      </div>
-    </div>
-  );
-}
-
-export function HeroScore({ data }: HeroScoreProps) {
+export function HeroScore({ data, index }: HeroScoreProps) {
   const [open, setOpen] = useState(false);
 
   const { score, contributors } = useMemo(() => {
-    const cs = computeContributors(data);
-    if (cs.length === 0) return { score: 0, contributors: [] };
+    if (!hasDataAt(data, index)) return { score: 0, contributors: [] as Contributor[] };
+    const cs = computeContributors(data, index);
+    if (cs.length === 0) return { score: 0, contributors: [] as Contributor[] };
     const totalWeight = cs.reduce((a, c) => a + c.weight, 0);
     const weighted = cs.reduce((a, c) => a + c.score * c.weight, 0) / totalWeight;
     return { score: Math.round(weighted), contributors: cs };
-  }, [data]);
+  }, [data, index]);
 
-  if (contributors.length === 0) return null;
+  if (contributors.length === 0) {
+    return (
+      <div className="px-8 pt-5 max-md:px-4">
+        <Card className="flex flex-col items-center gap-2 py-8">
+          <div className="text-[11px] uppercase tracking-wider text-text2">Readiness</div>
+          <div className="text-sm text-text2">この日のデータがありません</div>
+        </Card>
+      </div>
+    );
+  }
 
   const zone = zoneFor(score);
   const message = contextMessage(score, contributors);
@@ -327,7 +178,11 @@ export function HeroScore({ data }: HeroScoreProps) {
         <p className="max-w-md text-center text-sm text-text2">{message}</p>
         <div className="text-[11px] text-text3">タップで詳細を表示</div>
       </Card>
-      {open && <DetailSheet contributors={contributors} onClose={() => setOpen(false)} />}
+      {open && (
+        <BottomSheet title="Contributors" onClose={() => setOpen(false)} snapPoints={[60, 85]}>
+          <ContributorList contributors={contributors} />
+        </BottomSheet>
+      )}
     </div>
   );
 }

--- a/src/components/MetricDetailSheet.tsx
+++ b/src/components/MetricDetailSheet.tsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from 'react';
+import {
+  ResponsiveContainer,
+  LineChart, Line,
+  XAxis, YAxis, CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import type { HealthData } from '../types/health';
+import { BottomSheet } from './ui/BottomSheet';
+
+export type MetricKey =
+  | 'resting_hr' | 'steps' | 'sleep' | 'hrv'
+  | 'spo2' | 'sedentary' | 'weight' | 'body_fat';
+
+interface MetricConfig {
+  label: string;
+  color: string;
+  unit: string;
+  series: (data: HealthData) => (number | null)[];
+  format: (v: number) => string;
+  note: string;
+}
+
+function fmtMinutes(v: number): string {
+  return `${Math.floor(v / 60)}h ${Math.round(v % 60)}m`;
+}
+
+const METRICS: Record<MetricKey, MetricConfig> = {
+  resting_hr: {
+    label: '安静時心拍数', color: '#ff6b6b', unit: 'bpm',
+    series: (d) => d.resting_hr, format: (v) => String(Math.round(v)),
+    note: '低いほど回復状態が良好とされます（正常: 60〜100 bpm）',
+  },
+  steps: {
+    label: '歩数', color: '#00d68f', unit: '歩',
+    series: (d) => d.steps, format: (v) => Math.round(v).toLocaleString(),
+    note: '目標は 10,000 歩です',
+  },
+  sleep: {
+    label: '睡眠時間', color: '#a78bfa', unit: '',
+    series: (d) => d.sleep_minutes, format: fmtMinutes,
+    note: '目標は 8 時間です',
+  },
+  hrv: {
+    label: 'HRV（自律神経ゆらぎ）', color: '#00d68f', unit: 'ms',
+    series: (d) => d.hrv_rmssd, format: (v) => v.toFixed(1),
+    note: '個人差が大きいため自分自身の推移を参考にしてください',
+  },
+  spo2: {
+    label: '血中酸素濃度', color: '#00bcd4', unit: '%',
+    series: (d) => d.spo2_avg, format: (v) => v.toFixed(1),
+    note: '正常範囲: 95〜100%（睡眠中に計測）',
+  },
+  sedentary: {
+    label: '座位時間', color: '#7d8590', unit: '',
+    series: (d) => d.sedentary_minutes, format: fmtMinutes,
+    note: '長時間の座位は健康リスクを高めます',
+  },
+  weight: {
+    label: '体重', color: '#f6c177', unit: 'kg',
+    series: (d) => d.weight, format: (v) => v.toFixed(1),
+    note: 'TANITA 体組成計で計測',
+  },
+  body_fat: {
+    label: '体脂肪率', color: '#eb6f92', unit: '%',
+    series: (d) => d.body_fat, format: (v) => v.toFixed(1),
+    note: 'TANITA 体組成計で計測',
+  },
+};
+
+const RANGES = [7, 14, 30] as const;
+
+interface MetricDetailSheetProps {
+  metric: MetricKey;
+  data: HealthData;
+  index: number;
+  onClose: () => void;
+}
+
+function shortDate(d: string) {
+  const m = d.match(/(\d+)-(\d+)$/);
+  return m ? `${parseInt(m[1])}/${parseInt(m[2])}` : d;
+}
+
+export function MetricDetailSheet({ metric, data, index, onClose }: MetricDetailSheetProps) {
+  const [range, setRange] = useState<(typeof RANGES)[number]>(7);
+  const cfg = METRICS[metric];
+
+  const { chartData, stats, current } = useMemo(() => {
+    const series = cfg.series(data);
+    const from = Math.max(0, index - range + 1);
+    const window = data.dates
+      .slice(from, index + 1)
+      .map((d, i) => ({ date: d, value: series[from + i] }))
+      .filter((r): r is { date: string; value: number } => r.value !== null && r.value !== 0);
+    const values = window.map((r) => r.value);
+    return {
+      chartData: window,
+      stats: values.length > 0
+        ? {
+            avg: values.reduce((a, b) => a + b, 0) / values.length,
+            min: Math.min(...values),
+            max: Math.max(...values),
+          }
+        : null,
+      current: series[index],
+    };
+  }, [cfg, data, index, range]);
+
+  return (
+    <BottomSheet title={cfg.label} onClose={onClose}>
+      <div className="mb-3 flex items-end justify-between">
+        <div>
+          <span className="text-3xl font-bold" style={{ color: cfg.color }}>
+            {current !== null && current !== 0 ? cfg.format(current) : '—'}
+          </span>
+          {cfg.unit && <span className="ml-1 text-sm text-text2">{cfg.unit}</span>}
+          <span className="ml-2 text-xs text-text3">{data.dates[index]}</span>
+        </div>
+        <div className="flex shrink-0 gap-1" role="group" aria-label="表示期間">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`rounded-full px-2.5 py-1 text-[11px] whitespace-nowrap transition-colors ${
+                range === r
+                  ? 'bg-accent/20 font-semibold text-accent'
+                  : 'text-text2 hover:bg-card2'
+              }`}
+            >
+              {r}日
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {chartData.length >= 2 ? (
+        <ResponsiveContainer width="100%" height={180}>
+          <LineChart data={chartData} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
+            <CartesianGrid stroke="#21262d" strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickFormatter={shortDate}
+              tick={{ fill: '#7d8590', fontSize: 10 }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tick={{ fill: '#7d8590', fontSize: 10 }}
+              axisLine={false}
+              tickLine={false}
+              width={44}
+              domain={['auto', 'auto']}
+            />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const p = payload[0];
+                return (
+                  <div className="rounded-md border border-border bg-card2 px-2.5 py-1.5 text-xs text-text">
+                    {cfg.format(Number(p.value))}{cfg.unit && ` ${cfg.unit}`}
+                  </div>
+                );
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke={cfg.color}
+              strokeWidth={2.5}
+              dot={{ r: 3, fill: cfg.color }}
+              activeDot={{ r: 5 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-[180px] items-center justify-center text-xs text-text2">
+          この期間のデータが不足しています
+        </div>
+      )}
+
+      {stats && (
+        <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+          {[
+            { label: `${range}日平均`, value: stats.avg },
+            { label: '最小', value: stats.min },
+            { label: '最大', value: stats.max },
+          ].map((s) => (
+            <div key={s.label} className="rounded-lg bg-card2 py-2">
+              <div className="text-[10px] text-text3">{s.label}</div>
+              <div className="text-sm font-semibold text-text">
+                {cfg.format(s.value)}{cfg.unit && <span className="text-[10px] text-text2"> {cfg.unit}</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-3 text-[11px] text-text3">※{cfg.note}</p>
+    </BottomSheet>
+  );
+}

--- a/src/components/SleepTimeline.tsx
+++ b/src/components/SleepTimeline.tsx
@@ -6,7 +6,7 @@ interface SleepTimelineProps {
 }
 
 const colorMap: Record<string, string> = {
-  deep: '#1a237e', light: '#5c6bc0', rem: '#26a69a', wake: '#ef5350',
+  deep: '#3949ab', light: '#9fa8da', rem: '#26a69a', wake: '#ef5350',
 };
 const nameMap: Record<string, string> = {
   deep: '深い眠り', light: '浅い眠り', rem: 'レム睡眠', wake: '覚醒',
@@ -78,7 +78,7 @@ export function SleepTimeline({ timeline }: SleepTimelineProps) {
       {timeline.shortData && timeline.shortData.length > 0 && (
         <>
           <button
-            className="mt-1.5 cursor-pointer rounded border border-accent bg-transparent px-2 py-0.5 text-[11px] text-accent hover:bg-accent/10"
+            className="mt-1.5 cursor-pointer self-start rounded border border-accent bg-transparent px-2 py-0.5 text-[11px] text-accent hover:bg-accent/10"
             onClick={() => setShowShort((p) => !p)}
           >
             {showShort ? '短い覚醒を非表示' : `短い覚醒を表示 (${timeline.shortData.length}回)`}

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -5,6 +5,53 @@ interface SummaryCardsProps {
   data: HealthData;
 }
 
+type Zone = 'good' | 'warning' | 'attention' | 'neutral';
+
+const ZONE_STYLE: Record<Zone, { color: string; icon: string }> = {
+  good: { color: '#00d68f', icon: '✓' },
+  warning: { color: '#ffb347', icon: '⚠' },
+  attention: { color: '#ff6b6b', icon: '!' },
+  neutral: { color: '#7d8590', icon: '' },
+};
+
+interface Context {
+  arrow: string;
+  text: string;
+  zone: Zone;
+}
+
+/**
+ * 直近値をベースライン（直近値を除く系列平均）と比較し、
+ * トレンド矢印・差分テキスト・ゾーンを算出する。
+ * goodWhen='none' はゾーン判定なし（体重など良し悪しが一概に言えない指標）。
+ */
+function contextOf(
+  arr: (number | null)[] | undefined,
+  goodWhen: 'up' | 'down' | 'none',
+): Context | null {
+  if (!arr) return null;
+  const values = arr
+    .map((v, i) => ({ v, i }))
+    .filter((x): x is { v: number; i: number } => x.v !== null && x.v !== 0);
+  if (values.length < 2) return null;
+
+  const last = values[values.length - 1].v;
+  const prior = values.slice(0, -1).map((x) => x.v);
+  const baseline = prior.reduce((a, b) => a + b, 0) / prior.length;
+  if (baseline === 0) return null;
+
+  const diffPct = ((last - baseline) / baseline) * 100;
+  const arrow = diffPct > 3 ? '↗' : diffPct < -3 ? '↘' : '→';
+  const text = `平均比 ${diffPct >= 0 ? '+' : ''}${Math.round(diffPct)}%`;
+
+  let zone: Zone = 'neutral';
+  if (goodWhen !== 'none') {
+    const signedDiff = goodWhen === 'up' ? diffPct : -diffPct;
+    zone = signedDiff >= -3 ? 'good' : signedDiff >= -10 ? 'warning' : 'attention';
+  }
+  return { arrow, text, zone };
+}
+
 export function SummaryCards({ data }: SummaryCardsProps) {
   const last = data.dates.length - 1;
   if (last < 0) return null;
@@ -29,12 +76,14 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       unit: 'bpm',
       color: '#ff6b6b',
       sub: '正常: 60〜100',
+      context: contextOf(data.resting_hr, 'down'),
     },
     {
       label: '歩数',
       val: data.steps[last] > 0 ? data.steps[last].toLocaleString() : '—',
       color: data.steps[last] >= 10000 ? '#00d68f' : '#4ecdc4',
       sub: data.steps[last] >= 10000 ? '目標達成!' : '目標: 10,000',
+      context: contextOf(data.steps, 'up'),
     },
     {
       label: '睡眠',
@@ -44,6 +93,7 @@ export function SummaryCards({ data }: SummaryCardsProps) {
           : '—',
       color: '#a78bfa',
       sub: data.sleep_efficiency[last] ? `効率: ${data.sleep_efficiency[last]}%` : '',
+      context: contextOf(data.sleep_minutes, 'up'),
     },
     {
       label: 'HRV',
@@ -51,6 +101,7 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       unit: 'ms',
       color: '#00d68f',
       sub: '高いほど良好',
+      context: contextOf(data.hrv_rmssd, 'up'),
     },
     {
       label: '血中酸素',
@@ -58,12 +109,14 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       unit: '%',
       color: '#00bcd4',
       sub: '正常: 95〜100%',
+      context: contextOf(data.spo2_avg, 'up'),
     },
     {
       label: '座位時間',
       val: sedentary !== null ? `${Math.floor(sedentary / 60)}h ${sedentary % 60}m` : '—',
       color: '#7d8590',
       sub: '長時間の座位に注意',
+      context: contextOf(data.sedentary_minutes, 'down'),
     },
     {
       label: '体重',
@@ -71,6 +124,7 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       unit: 'kg',
       color: '#f6c177',
       sub: 'TANITA 計測',
+      context: contextOf(data.weight, 'none'),
     },
     {
       label: '体脂肪率',
@@ -78,6 +132,7 @@ export function SummaryCards({ data }: SummaryCardsProps) {
       unit: '%',
       color: '#eb6f92',
       sub: 'TANITA 計測',
+      context: contextOf(data.body_fat, 'none'),
     },
   ];
 
@@ -90,6 +145,18 @@ export function SummaryCards({ data }: SummaryCardsProps) {
             {c.val}
             {c.unit && <span className="text-[13px] text-text2">{c.unit}</span>}
           </div>
+          {c.context && c.val !== '—' && (
+            <div
+              className="mt-0.5 text-[11px] font-medium"
+              style={{ color: ZONE_STYLE[c.context.zone].color }}
+            >
+              <span aria-hidden="true">{c.context.arrow} </span>
+              {c.context.text}
+              {ZONE_STYLE[c.context.zone].icon && (
+                <span aria-hidden="true"> {ZONE_STYLE[c.context.zone].icon}</span>
+              )}
+            </div>
+          )}
           <div className="mt-1 text-[11px] text-text2">{c.sub}</div>
         </Card>
       ))}

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react';
 import type { HealthData } from '../types/health';
 import { Card } from './ui/Card';
+import { MetricDetailSheet, type MetricKey } from './MetricDetailSheet';
 
 interface SummaryCardsProps {
   data: HealthData;
+  index: number;
 }
 
 type Zone = 'good' | 'warning' | 'attention' | 'neutral';
@@ -21,26 +24,28 @@ interface Context {
 }
 
 /**
- * 直近値をベースライン（直近値を除く系列平均）と比較し、
+ * 選択日の値をベースライン（選択日を除く系列平均）と比較し、
  * トレンド矢印・差分テキスト・ゾーンを算出する。
  * goodWhen='none' はゾーン判定なし（体重など良し悪しが一概に言えない指標）。
  */
 function contextOf(
   arr: (number | null)[] | undefined,
   goodWhen: 'up' | 'down' | 'none',
+  index: number,
 ): Context | null {
   if (!arr) return null;
-  const values = arr
-    .map((v, i) => ({ v, i }))
-    .filter((x): x is { v: number; i: number } => x.v !== null && x.v !== 0);
-  if (values.length < 2) return null;
+  const current = arr[index];
+  if (current === null || current === undefined || current === 0) return null;
 
-  const last = values[values.length - 1].v;
-  const prior = values.slice(0, -1).map((x) => x.v);
-  const baseline = prior.reduce((a, b) => a + b, 0) / prior.length;
+  const others = arr
+    .filter((_, i) => i !== index)
+    .filter((v): v is number => v !== null && v !== 0);
+  if (others.length < 1) return null;
+
+  const baseline = others.reduce((a, b) => a + b, 0) / others.length;
   if (baseline === 0) return null;
 
-  const diffPct = ((last - baseline) / baseline) * 100;
+  const diffPct = ((current - baseline) / baseline) * 100;
   const arrow = diffPct > 3 ? '↗' : diffPct < -3 ? '↘' : '→';
   const text = `平均比 ${diffPct >= 0 ? '+' : ''}${Math.round(diffPct)}%`;
 
@@ -52,114 +57,147 @@ function contextOf(
   return { arrow, text, zone };
 }
 
-export function SummaryCards({ data }: SummaryCardsProps) {
-  const last = data.dates.length - 1;
-  if (last < 0) return null;
+export function SummaryCards({ data, index }: SummaryCardsProps) {
+  const [openMetric, setOpenMetric] = useState<MetricKey | null>(null);
 
-  const sleepMin = data.sleep_minutes?.[last] ?? 0;
-  const sedentary = data.sedentary_minutes?.[last] ?? null;
+  if (index < 0 || index >= data.dates.length) return null;
 
-  const findLatest = (arr: (number | null)[] | undefined) => {
-    if (!arr) return null;
-    for (let i = arr.length - 1; i >= 0; i--) {
-      if (arr[i] !== null && arr[i] !== undefined) return arr[i];
-    }
-    return null;
-  };
-  const weight = findLatest(data.weight);
-  const bodyFat = findLatest(data.body_fat);
+  const sleepMin = data.sleep_minutes?.[index] ?? 0;
+  const sedentary = data.sedentary_minutes?.[index] ?? null;
+  const weight = data.weight?.[index] ?? null;
+  const bodyFat = data.body_fat?.[index] ?? null;
 
-  const cards = [
+  const cards: Array<{
+    metric: MetricKey;
+    label: string;
+    val: string;
+    unit?: string;
+    color: string;
+    sub: string;
+    context: Context | null;
+  }> = [
     {
+      metric: 'resting_hr',
       label: '安静時心拍数',
-      val: data.resting_hr[last] !== null ? String(data.resting_hr[last]) : '—',
+      val: data.resting_hr[index] !== null ? String(data.resting_hr[index]) : '—',
       unit: 'bpm',
       color: '#ff6b6b',
       sub: '正常: 60〜100',
-      context: contextOf(data.resting_hr, 'down'),
+      context: contextOf(data.resting_hr, 'down', index),
     },
     {
+      metric: 'steps',
       label: '歩数',
-      val: data.steps[last] > 0 ? data.steps[last].toLocaleString() : '—',
-      color: data.steps[last] >= 10000 ? '#00d68f' : '#4ecdc4',
-      sub: data.steps[last] >= 10000 ? '目標達成!' : '目標: 10,000',
-      context: contextOf(data.steps, 'up'),
+      val: data.steps[index] > 0 ? data.steps[index].toLocaleString() : '—',
+      color: data.steps[index] >= 10000 ? '#00d68f' : '#4ecdc4',
+      sub: data.steps[index] >= 10000 ? '目標達成!' : '目標: 10,000',
+      context: contextOf(data.steps, 'up', index),
     },
     {
+      metric: 'sleep',
       label: '睡眠',
       val:
         sleepMin > 0
           ? `${Math.floor(sleepMin / 60)}h ${sleepMin % 60}m`
           : '—',
       color: '#a78bfa',
-      sub: data.sleep_efficiency[last] ? `効率: ${data.sleep_efficiency[last]}%` : '',
-      context: contextOf(data.sleep_minutes, 'up'),
+      sub: data.sleep_efficiency[index] ? `効率: ${data.sleep_efficiency[index]}%` : '',
+      context: contextOf(data.sleep_minutes, 'up', index),
     },
     {
+      metric: 'hrv',
       label: 'HRV',
-      val: data.hrv_rmssd[last] !== null ? data.hrv_rmssd[last]!.toFixed(1) : '—',
+      val: data.hrv_rmssd[index] !== null ? data.hrv_rmssd[index]!.toFixed(1) : '—',
       unit: 'ms',
       color: '#00d68f',
       sub: '高いほど良好',
-      context: contextOf(data.hrv_rmssd, 'up'),
+      context: contextOf(data.hrv_rmssd, 'up', index),
     },
     {
+      metric: 'spo2',
       label: '血中酸素',
-      val: data.spo2_avg[last] !== null ? data.spo2_avg[last]!.toFixed(1) : '—',
+      val: data.spo2_avg[index] !== null ? data.spo2_avg[index]!.toFixed(1) : '—',
       unit: '%',
       color: '#00bcd4',
       sub: '正常: 95〜100%',
-      context: contextOf(data.spo2_avg, 'up'),
+      context: contextOf(data.spo2_avg, 'up', index),
     },
     {
+      metric: 'sedentary',
       label: '座位時間',
       val: sedentary !== null ? `${Math.floor(sedentary / 60)}h ${sedentary % 60}m` : '—',
       color: '#7d8590',
       sub: '長時間の座位に注意',
-      context: contextOf(data.sedentary_minutes, 'down'),
+      context: contextOf(data.sedentary_minutes, 'down', index),
     },
     {
+      metric: 'weight',
       label: '体重',
       val: weight !== null ? weight.toFixed(1) : '—',
       unit: 'kg',
       color: '#f6c177',
       sub: 'TANITA 計測',
-      context: contextOf(data.weight, 'none'),
+      context: contextOf(data.weight, 'none', index),
     },
     {
+      metric: 'body_fat',
       label: '体脂肪率',
       val: bodyFat !== null ? bodyFat.toFixed(1) : '—',
       unit: '%',
       color: '#eb6f92',
       sub: 'TANITA 計測',
-      context: contextOf(data.body_fat, 'none'),
+      context: contextOf(data.body_fat, 'none', index),
     },
   ];
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 px-8 py-5 max-md:grid-cols-2 max-md:px-4">
-      {cards.map((c) => (
-        <Card key={c.label} className="text-center">
-          <div className="mb-1.5 text-[11px] tracking-wide text-text2">{c.label}</div>
-          <div className="text-[32px] font-bold" style={{ color: c.color ?? undefined }}>
-            {c.val}
-            {c.unit && <span className="text-[13px] text-text2">{c.unit}</span>}
-          </div>
-          {c.context && c.val !== '—' && (
-            <div
-              className="mt-0.5 text-[11px] font-medium"
-              style={{ color: ZONE_STYLE[c.context.zone].color }}
-            >
-              <span aria-hidden="true">{c.context.arrow} </span>
-              {c.context.text}
-              {ZONE_STYLE[c.context.zone].icon && (
-                <span aria-hidden="true"> {ZONE_STYLE[c.context.zone].icon}</span>
-              )}
+    <>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 px-8 py-5 max-md:grid-cols-2 max-md:px-4">
+        {cards.map((c) => (
+          <Card
+            key={c.label}
+            className="relative cursor-pointer text-center transition-colors hover:border-accent"
+            role="button"
+            tabIndex={0}
+            onClick={() => setOpenMetric(c.metric)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setOpenMetric(c.metric);
+              }
+            }}
+            aria-label={`${c.label}の詳細を表示`}
+          >
+            <span className="absolute top-2 right-2.5 text-xs text-text3" aria-hidden="true">›</span>
+            <div className="mb-1.5 text-[11px] tracking-wide text-text2">{c.label}</div>
+            <div className="text-[32px] font-bold" style={{ color: c.color ?? undefined }}>
+              {c.val}
+              {c.unit && <span className="text-[13px] text-text2">{c.unit}</span>}
             </div>
-          )}
-          <div className="mt-1 text-[11px] text-text2">{c.sub}</div>
-        </Card>
-      ))}
-    </div>
+            {c.context && c.val !== '—' && (
+              <div
+                className="mt-0.5 text-[11px] font-medium"
+                style={{ color: ZONE_STYLE[c.context.zone].color }}
+              >
+                <span aria-hidden="true">{c.context.arrow} </span>
+                {c.context.text}
+                {ZONE_STYLE[c.context.zone].icon && (
+                  <span aria-hidden="true"> {ZONE_STYLE[c.context.zone].icon}</span>
+                )}
+              </div>
+            )}
+            <div className="mt-1 text-[11px] text-text2">{c.sub}</div>
+          </Card>
+        ))}
+      </div>
+      {openMetric && (
+        <MetricDetailSheet
+          metric={openMetric}
+          data={data}
+          index={index}
+          onClose={() => setOpenMetric(null)}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import type { HealthData } from '../types/health';
 import { Card } from './ui/Card';
+import { CountUp } from './ui/CountUp';
+import { Sparkline } from './ui/Sparkline';
 import { MetricDetailSheet, type MetricKey } from './MetricDetailSheet';
 
 interface SummaryCardsProps {
@@ -57,138 +59,193 @@ function contextOf(
   return { arrow, text, zone };
 }
 
+const SPARK_DAYS = 7;
+
+/** 選択日までの直近7日間のスパークラインデータ */
+function sparkPoints(
+  data: HealthData,
+  arr: (number | null)[] | undefined,
+  index: number,
+): { date: string; value: number | null }[] {
+  if (!arr) return [];
+  const from = Math.max(0, index - SPARK_DAYS + 1);
+  return data.dates.slice(from, index + 1).map((d, i) => {
+    const v = arr[from + i];
+    return { date: d, value: v === 0 ? null : v };
+  });
+}
+
+/** 「7日間HRVトレンド: 12%上昇」形式のアクセシビリティラベル */
+function sparkLabel(label: string, points: { value: number | null }[]): string {
+  const valid = points.map((p) => p.value).filter((v): v is number => v !== null);
+  if (valid.length < 2) return `${SPARK_DAYS}日間${label}トレンド`;
+  const first = valid[0];
+  const lastV = valid[valid.length - 1];
+  if (first === 0) return `${SPARK_DAYS}日間${label}トレンド`;
+  const pct = Math.round(((lastV - first) / first) * 100);
+  const dir = pct > 3 ? '上昇' : pct < -3 ? '下降' : '横ばい';
+  return `${SPARK_DAYS}日間${label}トレンド: ${Math.abs(pct)}%${dir}`;
+}
+
+const fmtMinutes = (v: number) => `${Math.floor(v / 60)}h ${Math.round(v % 60)}m`;
+
 export function SummaryCards({ data, index }: SummaryCardsProps) {
   const [openMetric, setOpenMetric] = useState<MetricKey | null>(null);
 
   if (index < 0 || index >= data.dates.length) return null;
 
-  const sleepMin = data.sleep_minutes?.[index] ?? 0;
-  const sedentary = data.sedentary_minutes?.[index] ?? null;
-  const weight = data.weight?.[index] ?? null;
-  const bodyFat = data.body_fat?.[index] ?? null;
+  const nz = (v: number | null | undefined) => (v === null || v === undefined || v === 0 ? null : v);
 
   const cards: Array<{
     metric: MetricKey;
     label: string;
-    val: string;
+    value: number | null;
+    format: (v: number) => string;
     unit?: string;
     color: string;
     sub: string;
     context: Context | null;
+    series: (number | null)[] | undefined;
+    band?: [number, number];
   }> = [
     {
       metric: 'resting_hr',
       label: '安静時心拍数',
-      val: data.resting_hr[index] !== null ? String(data.resting_hr[index]) : '—',
+      value: nz(data.resting_hr[index]),
+      format: (v) => String(Math.round(v)),
       unit: 'bpm',
       color: '#ff6b6b',
       sub: '正常: 60〜100',
       context: contextOf(data.resting_hr, 'down', index),
+      series: data.resting_hr,
+      band: [60, 100],
     },
     {
       metric: 'steps',
       label: '歩数',
-      val: data.steps[index] > 0 ? data.steps[index].toLocaleString() : '—',
+      value: nz(data.steps[index]),
+      format: (v) => Math.round(v).toLocaleString(),
       color: data.steps[index] >= 10000 ? '#00d68f' : '#4ecdc4',
       sub: data.steps[index] >= 10000 ? '目標達成!' : '目標: 10,000',
       context: contextOf(data.steps, 'up', index),
+      series: data.steps,
     },
     {
       metric: 'sleep',
       label: '睡眠',
-      val:
-        sleepMin > 0
-          ? `${Math.floor(sleepMin / 60)}h ${sleepMin % 60}m`
-          : '—',
+      value: nz(data.sleep_minutes[index]),
+      format: fmtMinutes,
       color: '#a78bfa',
       sub: data.sleep_efficiency[index] ? `効率: ${data.sleep_efficiency[index]}%` : '',
       context: contextOf(data.sleep_minutes, 'up', index),
+      series: data.sleep_minutes,
+      band: [420, 540],
     },
     {
       metric: 'hrv',
       label: 'HRV',
-      val: data.hrv_rmssd[index] !== null ? data.hrv_rmssd[index]!.toFixed(1) : '—',
+      value: nz(data.hrv_rmssd[index]),
+      format: (v) => v.toFixed(1),
       unit: 'ms',
       color: '#00d68f',
       sub: '高いほど良好',
       context: contextOf(data.hrv_rmssd, 'up', index),
+      series: data.hrv_rmssd,
     },
     {
       metric: 'spo2',
       label: '血中酸素',
-      val: data.spo2_avg[index] !== null ? data.spo2_avg[index]!.toFixed(1) : '—',
+      value: nz(data.spo2_avg[index]),
+      format: (v) => v.toFixed(1),
       unit: '%',
       color: '#00bcd4',
       sub: '正常: 95〜100%',
       context: contextOf(data.spo2_avg, 'up', index),
+      series: data.spo2_avg,
+      band: [95, 100],
     },
     {
       metric: 'sedentary',
       label: '座位時間',
-      val: sedentary !== null ? `${Math.floor(sedentary / 60)}h ${sedentary % 60}m` : '—',
+      value: nz(data.sedentary_minutes?.[index]),
+      format: fmtMinutes,
       color: '#7d8590',
       sub: '長時間の座位に注意',
       context: contextOf(data.sedentary_minutes, 'down', index),
+      series: data.sedentary_minutes,
     },
     {
       metric: 'weight',
       label: '体重',
-      val: weight !== null ? weight.toFixed(1) : '—',
+      value: nz(data.weight?.[index]),
+      format: (v) => v.toFixed(1),
       unit: 'kg',
       color: '#f6c177',
       sub: 'TANITA 計測',
       context: contextOf(data.weight, 'none', index),
+      series: data.weight,
     },
     {
       metric: 'body_fat',
       label: '体脂肪率',
-      val: bodyFat !== null ? bodyFat.toFixed(1) : '—',
+      value: nz(data.body_fat?.[index]),
+      format: (v) => v.toFixed(1),
       unit: '%',
       color: '#eb6f92',
       sub: 'TANITA 計測',
       context: contextOf(data.body_fat, 'none', index),
+      series: data.body_fat,
     },
   ];
 
   return (
     <>
       <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 px-8 py-5 max-md:grid-cols-2 max-md:px-4">
-        {cards.map((c) => (
-          <Card
-            key={c.label}
-            className="relative cursor-pointer text-center transition-colors hover:border-accent"
-            role="button"
-            tabIndex={0}
-            onClick={() => setOpenMetric(c.metric)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                setOpenMetric(c.metric);
-              }
-            }}
-            aria-label={`${c.label}の詳細を表示`}
-          >
-            <span className="absolute top-2 right-2.5 text-xs text-text3" aria-hidden="true">›</span>
-            <div className="mb-1.5 text-[11px] tracking-wide text-text2">{c.label}</div>
-            <div className="text-[32px] font-bold" style={{ color: c.color ?? undefined }}>
-              {c.val}
-              {c.unit && <span className="text-[13px] text-text2">{c.unit}</span>}
-            </div>
-            {c.context && c.val !== '—' && (
-              <div
-                className="mt-0.5 text-[11px] font-medium"
-                style={{ color: ZONE_STYLE[c.context.zone].color }}
-              >
-                <span aria-hidden="true">{c.context.arrow} </span>
-                {c.context.text}
-                {ZONE_STYLE[c.context.zone].icon && (
-                  <span aria-hidden="true"> {ZONE_STYLE[c.context.zone].icon}</span>
-                )}
+        {cards.map((c) => {
+          const points = sparkPoints(data, c.series, index);
+          return (
+            <Card
+              key={c.label}
+              className="relative cursor-pointer text-center transition-colors hover:border-accent"
+              role="button"
+              tabIndex={0}
+              onClick={() => setOpenMetric(c.metric)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setOpenMetric(c.metric);
+                }
+              }}
+              aria-label={`${c.label}の詳細を表示`}
+            >
+              <span className="absolute top-2 right-2.5 text-xs text-text3" aria-hidden="true">›</span>
+              <div className="mb-1.5 text-[11px] tracking-wide text-text2">{c.label}</div>
+              <div className="text-[32px] font-bold" style={{ color: c.color ?? undefined }}>
+                {c.value !== null ? <CountUp value={c.value} format={c.format} /> : '—'}
+                {c.unit && <span className="text-[13px] text-text2">{c.unit}</span>}
               </div>
-            )}
-            <div className="mt-1 text-[11px] text-text2">{c.sub}</div>
-          </Card>
-        ))}
+              {c.context && c.value !== null && (
+                <div
+                  className="mt-0.5 text-[11px] font-medium"
+                  style={{ color: ZONE_STYLE[c.context.zone].color }}
+                >
+                  <span aria-hidden="true">{c.context.arrow} </span>
+                  {c.context.text}
+                  {ZONE_STYLE[c.context.zone].icon && (
+                    <span aria-hidden="true"> {ZONE_STYLE[c.context.zone].icon}</span>
+                  )}
+                </div>
+              )}
+              <Sparkline
+                points={points}
+                color={c.color}
+                band={c.band}
+                ariaLabel={sparkLabel(c.label, points)}
+              />
+              <div className="mt-1 text-[11px] text-text2">{c.sub}</div>
+            </Card>
+          );
+        })}
       </div>
       {openMetric && (
         <MetricDetailSheet

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface BottomSheetProps {
+  title: React.ReactNode;
+  onClose: () => void;
+  children: React.ReactNode;
+  /** シート高さのスナップポイント（dvh%）。[プレビュー, フル] */
+  snapPoints?: [number, number];
+  /** 初期表示をフルにする場合 1 を指定 */
+  initialSnap?: 0 | 1;
+}
+
+const DRAG_THRESHOLD = 70;
+
+/**
+ * 依存ライブラリなしのボトムシート。
+ * ハンドルをドラッグしてプレビュー(40%)⇔フル(85%)を切替、
+ * プレビューからさらに下スワイプ・背景タップ・✕・Escで閉じる。
+ */
+export function BottomSheet({
+  title,
+  onClose,
+  children,
+  snapPoints = [40, 85],
+  initialSnap = 0,
+}: BottomSheetProps) {
+  const [snapIdx, setSnapIdx] = useState<0 | 1>(initialSnap);
+  const [dragY, setDragY] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const dragStart = useRef<number | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    dragStart.current = e.clientY;
+    setDragging(true);
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (dragStart.current === null) return;
+    setDragY(e.clientY - dragStart.current);
+  };
+  const onPointerUp = () => {
+    if (dragStart.current === null) return;
+    const dy = dragY;
+    dragStart.current = null;
+    setDragging(false);
+    setDragY(0);
+    if (dy > DRAG_THRESHOLD) {
+      if (snapIdx === 1) setSnapIdx(0);
+      else onClose();
+    } else if (dy < -DRAG_THRESHOLD && snapIdx === 0) {
+      setSnapIdx(1);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="flex w-full max-w-lg flex-col rounded-t-2xl border border-b-0 border-border bg-card"
+        style={{
+          height: `${snapPoints[snapIdx]}dvh`,
+          transform: dragY > 0 ? `translateY(${dragY}px)` : undefined,
+          transition: dragging ? 'none' : 'height 0.25s ease, transform 0.2s ease',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="shrink-0 cursor-grab touch-none px-5 pt-2 active:cursor-grabbing"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+        >
+          <div className="mx-auto h-1 w-10 rounded-full bg-border" />
+          <div className="flex items-center justify-between py-3">
+            <h3 className="text-base font-semibold text-text">{title}</h3>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => setSnapIdx(snapIdx === 0 ? 1 : 0)}
+                className="text-xs text-text2 hover:text-text"
+                aria-label={snapIdx === 0 ? '拡大' : '縮小'}
+              >
+                {snapIdx === 0 ? '⌃ 拡大' : '⌄ 縮小'}
+              </button>
+              <button onClick={onClose} className="text-text2 hover:text-text" aria-label="閉じる">
+                ✕
+              </button>
+            </div>
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-6">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/CountUp.tsx
+++ b/src/components/ui/CountUp.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useReducedMotion } from '../../lib/useReducedMotion';
+
+interface CountUpProps {
+  value: number;
+  /** 中間値も渡されるため、format 側で丸めること */
+  format?: (v: number) => string;
+  duration?: number;
+}
+
+/**
+ * 0→value をイージング付きでカウントアップ表示する。
+ * prefers-reduced-motion 時はアニメーションせず最終値を即時表示。
+ */
+export function CountUp({ value, format, duration = 800 }: CountUpProps) {
+  const reduced = useReducedMotion();
+  const [display, setDisplay] = useState(0);
+
+  useEffect(() => {
+    if (reduced) return;
+    let raf: number;
+    const start = performance.now();
+    const tick = (t: number) => {
+      const p = Math.min(1, (t - start) / duration);
+      const eased = 1 - Math.pow(1 - p, 3); // ease-out cubic
+      setDisplay(value * eased);
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [value, duration, reduced]);
+
+  const shown = reduced ? value : display;
+  return <>{format ? format(shown) : Math.round(shown).toLocaleString()}</>;
+}

--- a/src/components/ui/Sparkline.tsx
+++ b/src/components/ui/Sparkline.tsx
@@ -1,0 +1,54 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, ReferenceArea } from 'recharts';
+import { useReducedMotion } from '../../lib/useReducedMotion';
+
+interface SparklinePoint {
+  date: string;
+  value: number | null;
+}
+
+interface SparklineProps {
+  points: SparklinePoint[];
+  color: string;
+  /** 正常範囲帯 [下限, 上限]。表示ドメイン外は自動クリップ */
+  band?: [number, number];
+  ariaLabel: string;
+}
+
+/**
+ * MetricCard 内に埋め込む軸・グリッドなしのスパークライン（Tufte データワード）。
+ */
+export function Sparkline({ points, color, band, ariaLabel }: SparklineProps) {
+  const reduced = useReducedMotion();
+  const valid = points.filter((p) => p.value !== null);
+  if (valid.length < 2) return null;
+
+  return (
+    <div className="mx-auto h-12 w-full max-w-[150px]" role="img" aria-label={ariaLabel}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={points} margin={{ top: 4, right: 2, bottom: 2, left: 2 }}>
+          <XAxis dataKey="date" hide />
+          <YAxis hide domain={['auto', 'auto']} />
+          {band && (
+            <ReferenceArea
+              y1={band[0]}
+              y2={band[1]}
+              fill="rgba(125, 133, 144, 0.14)"
+              strokeWidth={0}
+              ifOverflow="hidden"
+            />
+          )}
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke={color}
+            strokeWidth={2}
+            dot={false}
+            connectNulls
+            isAnimationActive={!reduced}
+            animationDuration={800}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/data/sampleData.ts
+++ b/src/data/sampleData.ts
@@ -17,8 +17,6 @@ export const sampleData: HealthData = {
   spo2_min: [95.0, 94.5, 95.2, 94.0, 95.1, 95.3, 94.8],
   spo2_max: [99.0, 98.5, 99.2, 98.0, 98.8, 99.1, 98.6],
   sedentary_minutes: [780, 720, 800, 690, 750, 760, 710],
-  weight: [68.2, 68.0, 68.4, 67.8, 67.9, 68.1, 67.7],
-  body_fat: [21.5, 21.3, 21.8, 21.0, 21.2, 21.4, 20.9],
   sleep_timelines: [
     null, null, null, null, null, null,
     {

--- a/src/data/sampleData.ts
+++ b/src/data/sampleData.ts
@@ -17,6 +17,8 @@ export const sampleData: HealthData = {
   spo2_min: [95.0, 94.5, 95.2, 94.0, 95.1, 95.3, 94.8],
   spo2_max: [99.0, 98.5, 99.2, 98.0, 98.8, 99.1, 98.6],
   sedentary_minutes: [780, 720, 800, 690, 750, 760, 710],
+  weight: [68.2, 68.0, 68.4, 67.8, 67.9, 68.1, 67.7],
+  body_fat: [21.5, 21.3, 21.8, 21.0, 21.2, 21.4, 20.9],
   sleep_timelines: [
     null, null, null, null, null, null,
     {

--- a/src/index.css
+++ b/src/index.css
@@ -37,3 +37,19 @@ body {
   background-color: var(--color-bg);
   color: var(--color-text);
 }
+
+/* 日付切替時のクロスフェード */
+@keyframes fade-slide {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.animate-fade-slide {
+  animation: fade-slide 0.28s ease;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -53,3 +53,34 @@ body {
 .animate-fade-slide {
   animation: fade-slide 0.28s ease;
 }
+
+/* 目標達成時のセレブレーション（パルス＋バウンス） */
+@keyframes goal-pop {
+  0% {
+    transform: scale(1);
+    filter: none;
+  }
+  45% {
+    transform: scale(1.12);
+    filter: drop-shadow(0 0 10px rgba(255, 215, 0, 0.55));
+  }
+  70% {
+    transform: scale(0.96);
+  }
+  100% {
+    transform: scale(1);
+    filter: none;
+  }
+}
+
+.animate-goal-pop {
+  animation: goal-pop 0.6s ease-out 0.85s;
+}
+
+/* OSの「視差効果を減らす」設定を尊重 */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-slide,
+  .animate-goal-pop {
+    animation: none;
+  }
+}

--- a/src/lib/readiness.ts
+++ b/src/lib/readiness.ts
@@ -1,0 +1,149 @@
+import type { HealthData } from '../types/health';
+
+export interface Contributor {
+  label: string;
+  score: number;
+  weight: number;
+  detail: string;
+  baseline: string;
+}
+
+export function avg(values: (number | null)[]): number | null {
+  const nums = values.filter((v): v is number => v !== null && !Number.isNaN(v));
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function clamp(n: number, min = 0, max = 100): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function signed(n: number): string {
+  return n > 0 ? `+${n}` : `${n}`;
+}
+
+/** 指定日のデータが実質空（スコア計算不能）かどうか */
+export function hasDataAt(data: HealthData, index: number): boolean {
+  if (index < 0 || index >= data.dates.length) return false;
+  return Boolean(
+    (data.sleep_minutes[index] ?? 0) > 0 ||
+    (data.steps[index] ?? 0) > 0 ||
+    data.resting_hr[index] !== null ||
+    data.hrv_rmssd[index] !== null,
+  );
+}
+
+export function computeContributors(data: HealthData, index: number): Contributor[] {
+  if (index < 0 || index >= data.dates.length) return [];
+
+  // Sleep duration: 480 min (8h) target
+  const sleepMin = data.sleep_minutes[index] ?? 0;
+  const sleepDurTarget = 480;
+  const sleepDurScore = clamp((sleepMin / sleepDurTarget) * 100);
+  const sleepHours = Math.floor(sleepMin / 60);
+  const sleepRemMin = sleepMin % 60;
+  const sleepDiffMin = sleepMin - sleepDurTarget;
+
+  // Sleep efficiency: target 90%
+  const sleepEff = data.sleep_efficiency[index] ?? null;
+  const sleepEffTarget = 90;
+  const sleepEffScore = sleepEff !== null
+    ? clamp(50 + (sleepEff - sleepEffTarget) * 5)
+    : 50;
+
+  // Deep sleep: target 90 min
+  const deepMin = data.deep[index] ?? 0;
+  const deepTarget = 90;
+  const deepScore = clamp((deepMin / deepTarget) * 100);
+
+  // HRV: compare vs personal baseline (mean of series)
+  const hrvBaseline = avg(data.hrv_rmssd);
+  const hrvLast = data.hrv_rmssd[index];
+  const hrvScore = hrvLast !== null && hrvBaseline !== null && hrvBaseline > 0
+    ? clamp(50 + ((hrvLast - hrvBaseline) / hrvBaseline) * 100)
+    : 50;
+  const hrvDiffPct = hrvLast !== null && hrvBaseline !== null && hrvBaseline > 0
+    ? Math.round(((hrvLast - hrvBaseline) / hrvBaseline) * 100)
+    : null;
+
+  // Resting HR: lower vs baseline is better
+  const rhrBaseline = avg(data.resting_hr);
+  const rhrLast = data.resting_hr[index];
+  const rhrScore = rhrLast !== null && rhrBaseline !== null && rhrBaseline > 0
+    ? clamp(50 - ((rhrLast - rhrBaseline) / rhrBaseline) * 100)
+    : 50;
+  const rhrDiff = rhrLast !== null && rhrBaseline !== null
+    ? rhrLast - Math.round(rhrBaseline)
+    : null;
+
+  // Activity: steps vs daily goal (default 10k)
+  const stepsGoal = data.goals[index]?.steps ?? 10000;
+  const steps = data.steps[index] ?? 0;
+  const activityScore = clamp((steps / stepsGoal) * 100);
+
+  return [
+    {
+      label: '睡眠時間',
+      score: Math.round(sleepDurScore),
+      weight: 0.25,
+      detail: `${sleepHours}時間${sleepRemMin}分`,
+      baseline: `目標 ${sleepDurTarget / 60}時間に対し ${signed(sleepDiffMin)}分`,
+    },
+    {
+      label: '睡眠効率',
+      score: Math.round(sleepEffScore),
+      weight: 0.1,
+      detail: sleepEff !== null ? `${sleepEff}%` : '—',
+      baseline: sleepEff !== null
+        ? `目標 ${sleepEffTarget}% に対し ${signed(sleepEff - sleepEffTarget)}pt`
+        : 'データなし',
+    },
+    {
+      label: '深い睡眠',
+      score: Math.round(deepScore),
+      weight: 0.1,
+      detail: `${deepMin}分`,
+      baseline: `目標 ${deepTarget}分に対し ${signed(deepMin - deepTarget)}分`,
+    },
+    {
+      label: 'HRV',
+      score: Math.round(hrvScore),
+      weight: 0.2,
+      detail: hrvLast !== null ? `${hrvLast.toFixed(1)} ms` : '—',
+      baseline: hrvBaseline !== null && hrvDiffPct !== null
+        ? `平均 ${hrvBaseline.toFixed(1)} ms に対し ${signed(hrvDiffPct)}%`
+        : 'データなし',
+    },
+    {
+      label: '安静時心拍',
+      score: Math.round(rhrScore),
+      weight: 0.15,
+      detail: rhrLast !== null ? `${rhrLast} bpm` : '—',
+      baseline: rhrBaseline !== null && rhrDiff !== null
+        ? `平均 ${Math.round(rhrBaseline)} bpm に対し ${signed(rhrDiff)} bpm`
+        : 'データなし',
+    },
+    {
+      label: 'アクティビティ',
+      score: Math.round(activityScore),
+      weight: 0.2,
+      detail: `${steps.toLocaleString()} 歩`,
+      baseline: `目標 ${stepsGoal.toLocaleString()} 歩に対し ${Math.round((steps / stepsGoal) * 100)}%`,
+    },
+  ];
+}
+
+/** 指定日のReadinessスコア。データがない日は null */
+export function readinessScore(data: HealthData, index: number): number | null {
+  if (!hasDataAt(data, index)) return null;
+  const cs = computeContributors(data, index);
+  if (cs.length === 0) return null;
+  const totalWeight = cs.reduce((a, c) => a + c.weight, 0);
+  return Math.round(cs.reduce((a, c) => a + c.score * c.weight, 0) / totalWeight);
+}
+
+export function zoneFor(score: number): { color: string; ring: string; label: string } {
+  if (score >= 85) return { color: '#10b981', ring: '#10b981', label: '最適' };
+  if (score >= 70) return { color: '#f59e0b', ring: '#f59e0b', label: '良好' };
+  return { color: '#f43f5e', ring: '#f43f5e', label: '要注意' };
+}

--- a/src/lib/useReducedMotion.ts
+++ b/src/lib/useReducedMotion.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/** OSの「視差効果を減らす」設定を監視するフック */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
## 概要
UXイシュー P0×3件（#47 / #48 / #49）と P1×2件（#50 / #51）の実装、およびダークテーマの視認性修正をまとめたPRです。各機能はサンプルデータでブラウザ動作確認済み（tsc / eslint 通過）。

## 変更内容

### 見栄え修正
- 睡眠ステージの配色を調整（「深い眠り」が背景に溶けて見えない問題を修正）、チャート凡例テキストを読みやすいグレーに統一
- 心拍ゾーンドーナツは活動ゾーンのみ描画（安静帯に潰される問題を修正）、モバイルは縦並びに
- 睡眠タイムラインカードの下部余白を解消

### #47 サマリーカードの文脈情報
- 各カードに「→ 平均比 -1% ✓」形式のベースライン比較・トレンド矢印・ゾーン判定を追加（色＋アイコンの二重表現で色覚異常対応）

### #48 日付ナビゲーション
- `DateStrip` を上部に固定表示（横スクロール、各日にReadinessゾーン色ドット、「今日」ボタン）
- 月名タップでカレンダーグリッドをボトムシート表示、任意の日にジャンプ可能
- ダッシュボード全体を選択日ベースに刷新、左右スワイプで前日/翌日、切替時クロスフェード

### #49 ボトムシート型ドリルダウン
- 依存ライブラリなしの共通 `BottomSheet`（スナップポイント プレビュー/フル、ドラッグ・下スワイプ・背景タップ・✕・Escで閉じる）
- 全サマリーカードをタップ可能に（シェブロンで明示）。当日値＋7/14/30日トレンドチャート＋平均/最小/最大を表示
- HeroScore の Contributors シートも共通 BottomSheet に統一

### #50 インラインスパークライン
- 各カードに直近7日間のスパークライン（正常範囲帯付き、trend系aria-label付与）

### #51 アニメーション
- `CountUp`（数値カウントアップ）、ScoreRingアーク描画、GoalRingsリング充填＋達成時セレブレーション
- `prefers-reduced-motion` をJS/CSS両方で尊重

### その他
- Readinessスコア計算を `src/lib/readiness.ts` に共通化（任意日付で計算可能）
- `sampleData` の重複キー解消（PR #67 マージ後のリベース対応）

Closes #47
Closes #48
Closes #49
Closes #50
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Vyr1zwWWigzopbztY4g1z

---
_Generated by [Claude Code](https://claude.ai/code/session_014Vyr1zwWWigzopbztY4g1z)_